### PR TITLE
travis ci build status logo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 :version: 0.8.0
 :hardbreaks:
 
-image:https://travis-ci.org/redowl/swagger2markup-maven-plugin.svg["Build Status", link="https://travis-ci.org/Swagger2Markup/swagger2markup-maven-plugin"] image:https://coveralls.io/repos/redowl/swagger2markup-maven-plugin/badge.svg["Coverage Status", link="https://coveralls.io/r/redowl/swagger2markup-maven-plugin"] image:http://img.shields.io/badge/license-ASF2-blue.svg["Apache License 2", link="http://www.apache.org/licenses/LICENSE-2.0.txt"] image:https://img.shields.io/badge/Twitter-redowlytics-blue.svg["Twitter", link="https://twitter.com/redowlytics"]
+image:https://travis-ci.org/Swagger2Markup/swagger2markup-maven-plugin.svg["Build Status", link="https://travis-ci.org/Swagger2Markup/swagger2markup-maven-plugin"] image:https://coveralls.io/repos/redowl/swagger2markup-maven-plugin/badge.svg["Coverage Status", link="https://coveralls.io/r/redowl/swagger2markup-maven-plugin"] image:http://img.shields.io/badge/license-ASF2-blue.svg["Apache License 2", link="http://www.apache.org/licenses/LICENSE-2.0.txt"] image:https://img.shields.io/badge/Twitter-redowlytics-blue.svg["Twitter", link="https://twitter.com/redowlytics"]
 
 == Overview
 


### PR DESCRIPTION
You should also connect the new name space of the repo with
coveralls.io since it's still using the redowl account.