### PR TITLE
Extended folder as input still using one output file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.github.swagger2markup</groupId>
     <artifactId>swagger2markup-maven-plugin</artifactId>
-    <version>1.3.4-muddysteel-SNAPSHOT</version>
+    <version>1.3.5-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Swagger2Markup Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.github.swagger2markup</groupId>
     <artifactId>swagger2markup-maven-plugin</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.4-muddysteel-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Swagger2Markup Maven Plugin</name>

--- a/src/test/java/io/github/swagger2markup/Swagger2MarkupMojoTest.java
+++ b/src/test/java/io/github/swagger2markup/Swagger2MarkupMojoTest.java
@@ -117,6 +117,26 @@ public class Swagger2MarkupMojoTest {
     }
 
     @Test
+    public void shouldConvertIntoSubDirectoryOneFileIfMultipleSwaggerFilesInSameInput() throws Exception {
+        //given that the input folder contains two Swagger files
+        Swagger2MarkupMojo mojo = new Swagger2MarkupMojo();
+        mojo.swaggerInput = new File(INPUT_DIR).getAbsoluteFile().getAbsolutePath();
+        mojo.outputDir = new File(OUTPUT_DIR).getAbsoluteFile();
+        mojo.outputFile = new File(SWAGGER_OUTPUT_FILE);
+        
+        //when
+        mojo.execute();
+
+        //then
+        Iterable<String> outputFiles = recursivelyListFileNames(mojo.outputDir);
+        List<String> directoryNames = Arrays.asList(mojo.outputDir.listFiles()).stream().map(File::getName)
+                                            .collect(Collectors.toList());
+        assertThat(outputFiles).containsOnly("swagger.adoc");
+        assertThat(outputFiles.spliterator().getExactSizeIfKnown()).isEqualTo(2); // same set of files twice
+        assertThat(directoryNames).containsOnly("swagger", "swagger2");
+    }
+
+    @Test
     public void shouldConvertIntoMarkdown() throws Exception {
         //given
         Map<String, String> config = new HashMap<>();


### PR DESCRIPTION
Alter plugin logic such that if an input directory is specified AND an output file, then the output file will be created in the sub-directory associated with the original file.

This fixes a bug with same setup:  All input files are processed into the same, single output file, so last input file processed, wins.