### PR TITLE
Fix issue with mixed path separator in input path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iws
 .idea/
 .gradle/
+out/
 
 ## Eclipse ignores
 /.settings

--- a/src/main/java/io/github/swagger2markup/Swagger2MarkupMojo.java
+++ b/src/main/java/io/github/swagger2markup/Swagger2MarkupMojo.java
@@ -142,7 +142,7 @@ public class Swagger2MarkupMojo extends AbstractMojo {
              * If the folder the current Swagger file resides in contains at least one other Swagger file then the
              * output dir must have an extra subdir per file to avoid markdown files getting overwritten.
              */
-            outputDirAddendum += File.separator + extracSwaggerFileNameWithoutExtension(converter);
+            outputDirAddendum += File.separator + extractSwaggerFileNameWithoutExtension(converter);
         }
         return new File(outputDir, outputDirAddendum);
     }
@@ -159,7 +159,7 @@ public class Swagger2MarkupMojo extends AbstractMojo {
          */
         String swaggerFilePath = new File(converter.getContext().getSwaggerLocation()).getAbsolutePath(); // /Users/foo/bar-service/v1/bar.yaml
         String swaggerFileFolder = StringUtils.substringBeforeLast(swaggerFilePath, File.separator); // /Users/foo/bar-service/v1
-        return StringUtils.remove(swaggerFileFolder, swaggerInput); // /bar-service/v1
+        return StringUtils.remove(swaggerFileFolder, getSwaggerInputAbsolutePath()); // /bar-service/v1
     }
 
     private boolean multipleSwaggerFilesInSwaggerLocationFolder(Swagger2MarkupConverter converter) {
@@ -168,11 +168,20 @@ public class Swagger2MarkupMojo extends AbstractMojo {
         return swaggerFiles != null && swaggerFiles.size() > 1;
     }
 
-    private String extracSwaggerFileNameWithoutExtension(Swagger2MarkupConverter converter) {
+    private String extractSwaggerFileNameWithoutExtension(Swagger2MarkupConverter converter) {
         return FilenameUtils.removeExtension(new File(converter.getContext().getSwaggerLocation()).getName());
     }
 
     private Collection<File> getSwaggerFiles(File directory, boolean recursive) {
         return FileUtils.listFiles(directory, new String[]{"yaml", "yml", "json"}, recursive);
+    }
+
+    /*
+     * The 'swaggerInput' provided by the user can be anything; it's just a string. Hence, it could by Unix-style,
+     * Windows-style or even a mix thereof. This methods turns the input into a File and returns its absolute path. It
+     * will be platform dependent as far as file separators go but at least the separators will be consistent.
+     */
+    private String getSwaggerInputAbsolutePath(){
+        return new File(swaggerInput).getAbsolutePath();
     }
 }

--- a/src/test/java/io/github/swagger2markup/Swagger2MarkupMojoTest.java
+++ b/src/test/java/io/github/swagger2markup/Swagger2MarkupMojoTest.java
@@ -98,6 +98,25 @@ public class Swagger2MarkupMojoTest {
     }
 
     @Test
+    public void shouldConvertIntoDirectoryIfInputIsDirectoryWithMixedSeparators() throws Exception {
+        //given that the input folder contains a nested structure with Swagger files but path to it contains mixed file
+        //separators on Windows (/ and \)
+        Swagger2MarkupMojo mojo = new Swagger2MarkupMojo();
+        String swaggerInputPath = new File(RESOURCES_DIR).getAbsoluteFile().getAbsolutePath();
+        mojo.swaggerInput = replaceLast(swaggerInputPath, "\\", "/");
+        mojo.outputDir = new File(OUTPUT_DIR).getAbsoluteFile();
+
+        //when
+        mojo.execute();
+
+        //then
+        Iterable<String> outputFiles = recursivelyListFileNames(new File(mojo.outputDir, SWAGGER_DIR));
+        assertThat(outputFiles).containsOnly("definitions.adoc", "overview.adoc", "paths.adoc", "security.adoc");
+        outputFiles = listFileNames(new File(mojo.outputDir, SWAGGER_DIR + "2"), false);
+        assertThat(outputFiles).containsOnly("definitions.adoc", "overview.adoc", "paths.adoc", "security.adoc");
+    }
+
+    @Test
     public void shouldConvertIntoSubDirectoryIfMultipleSwaggerFilesInSameInput() throws Exception {
         //given that the input folder contains two Swagger files
         Swagger2MarkupMojo mojo = new Swagger2MarkupMojo();
@@ -123,7 +142,7 @@ public class Swagger2MarkupMojoTest {
         mojo.swaggerInput = new File(INPUT_DIR).getAbsoluteFile().getAbsolutePath();
         mojo.outputDir = new File(OUTPUT_DIR).getAbsoluteFile();
         mojo.outputFile = new File(SWAGGER_OUTPUT_FILE);
-        
+
         //when
         mojo.execute();
 
@@ -207,5 +226,16 @@ public class Swagger2MarkupMojoTest {
 
     private static void verifyFileContains(File file, String value) throws IOException {
         assertThat(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8)).contains(value);
+    }
+
+    private static String replaceLast(String input, String search, String replace) {
+        int lastIndex = input.lastIndexOf(search);
+        if (lastIndex > -1) {
+            return input.substring(0, lastIndex)
+                    + replace
+                    + input.substring(lastIndex + search.length(), input.length());
+        } else {
+            return input;
+        }
     }
 }


### PR DESCRIPTION
When you have something like this in your `pom.xm`

```xml
...
 <configuration>
  <swaggerInput>${project.basedir}/src/main/resources/services</swaggerInput>
...
```

running the plugin will fail on Windows if the input is a folder with multiple Swagger files. The effective input path in the above example on Windows might be something like `c:\data\myproject/src/main/resources/services` and the current code doesn't cope well with mixed file separators in the input path.