### PR TITLE
Fixed plugin descriptor

### DIFF
--- a/src/main/resources/META-INF/maven/io.github.swagger2markup/swagger2markup-maven-plugin/plugin-help.xml
+++ b/src/main/resources/META-INF/maven/io.github.swagger2markup/swagger2markup-maven-plugin/plugin-help.xml
@@ -7,7 +7,7 @@
   <description>Swagger2Markup Maven Plugin</description>
   <groupId>io.github.swagger2markup</groupId>
   <artifactId>swagger2markup-maven-plugin</artifactId>
-  <version>1.3.8-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <goalPrefix>swagger2markup</goalPrefix>
   <mojos>
     <mojo>

--- a/src/main/resources/META-INF/maven/plugin.xml
+++ b/src/main/resources/META-INF/maven/plugin.xml
@@ -7,7 +7,7 @@
   <description>Swagger2Markup Maven Plugin</description>
   <groupId>io.github.swagger2markup</groupId>
   <artifactId>swagger2markup-maven-plugin</artifactId>
-  <version>1.3.8-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <goalPrefix>swagger2markup</goalPrefix>
   <isolatedRealm>false</isolatedRealm>
   <inheritedByDefault>true</inheritedByDefault>


### PR DESCRIPTION
When using the 2.0.0-SNAPSHOT version from the jfrog repo I got following error:

```
 Invalid plugin descriptor for io.github.swagger2markup:swagger2markup-maven-plugin:2.0.0-SNAPSHOT (/home/ppatiern/.m2/repository/io/github/swagger2markup/swagger2markup-maven-plugin/2.0.0-SNAPSHOT/swagger2markup-maven-plugin-2.0.0-SNAPSHOT.jar), Plugin's descriptor contains the wrong version: 1.3.8-SNAPSHOT
```

This PR fixes the version in the plugin descriptor files.